### PR TITLE
FEAT - Quick file identification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 Research Data Format Identification
 ===================================
+*Web front end for file format identification and analysis*
+
+[![Build Status](https://travis-ci.org/carlwilson/fmt-sniff.svg?branch=master)](https://travis-ci.org/carlwilson/fmt-sniff "Travis-CI integration build")
+[![CodeCov Coverage](https://img.shields.io/codecov/c/github/carlwilson/fmt-sniff.svg)](https://codecov.io/gh/carlwilson/fmt-sniff/ "CodeCov test coverage figure")
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/ab34b42c50954e4192987e060321ea17)](https://www.codacy.com/app/openpreserve/fmt-sniff?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=carlwilson/fmt-sniff&amp;utm_campaign=Badge_Grade)
+[![Codacy Badge](https://api.codacy.com/project/badge/Coverage/ab34b42c50954e4192987e060321ea17)](https://www.codacy.com/app/openpreserve/fmt-sniff?utm_source=github.com&utm_medium=referral&utm_content=carlwilson/fmt-sniff&utm_campaign=Badge_Coverage)
+
 Description
 -----------
 The `fmt-sniff` project provides a set of Python tools that test format

--- a/corptest/__init__.py
+++ b/corptest/__init__.py
@@ -16,6 +16,7 @@ Initialisation module for package, kicks of the flask app.
 """
 import logging
 from os.path import abspath, dirname, join
+import sys
 __version__ = '0.2.0'
 from flask_sqlalchemy import SQLAlchemy
 from flask import Flask
@@ -32,6 +33,10 @@ logging.basicConfig(filename=APP.config['LOG_FILE'], level=logging.DEBUG,
 logging.info("Started JISC RDSS Format Identification app.")
 logging.debug("Configured logging.")
 logging.info("Initialising database.")
+if not APP.config['IS_FIDO']:
+    logging.warning("Python %r doesn't allow for inline FIDO support.", sys.version_info)
+else:
+    logging.info("Python %r enables inline FIDO support.", sys.version_info)
 
 from corptest.database import init_db
 init_db()

--- a/corptest/config.py
+++ b/corptest/config.py
@@ -10,7 +10,8 @@
 # about the terms of this license.
 #
 """Configuration for JISC RDSS format id Flask app."""
-import os
+import os.path
+import sys
 import tempfile
 
 from corptest.const import ENV_CONF_PROFILE, ENV_CONF_FILE, JISC_BUCKET
@@ -21,9 +22,11 @@ TEMP = tempfile.gettempdir()
 LOG_ROOT = TEMP
 class BaseConfig(object):# pylint: disable-msg=R0903
     """Base / default config, no debug logging and short log format."""
+    NAME = 'Default'
     HOST = HOST
     DEBUG = False
     TESTING = False
+    IS_FIDO = sys.version_info < (3, 0)
     LOG_FORMAT = '[%(filename)-15s:%(lineno)-5d] %(message)s'
     LOG_FILE = os.path.join(LOG_ROOT, 'jisc-rdss-format.log')
     SECRET_KEY = 'a5c020ced05af9ad3aacc6bba41beb5c7b6f750b846dadad'
@@ -40,10 +43,10 @@ class BaseConfig(object):# pylint: disable-msg=R0903
 
 class DevConfig(BaseConfig):# pylint: disable-msg=R0903
     """Developer level config, with debug logging and long log format."""
+    NAME = 'Development'
     DEBUG = True
     TESTING = True
     LOG_FORMAT = '[%(levelname)-8s %(filename)-15s:%(lineno)-5d %(funcName)-30s] %(message)s'
-    RDSS_ROOT = '/vagrant_data/'
     BUCKETS = [
         {
             'name' : 'JISC Test Bucket',
@@ -52,9 +55,15 @@ class DevConfig(BaseConfig):# pylint: disable-msg=R0903
         }
     ]
 
+class VagrantConfig(DevConfig):# pylint: disable-msg=R0903
+    """Vagrant config, with debug logging and long log format."""
+    NAME = 'Vagrant'
+    RDSS_ROOT = '/vagrant_data/'
+
 CONFIGS = {
     "dev": 'corptest.config.DevConfig',
-    "default": 'corptest.config.BaseConfig'
+    "default": 'corptest.config.BaseConfig',
+    "vagrant": 'corptest.config.VagrantConfig'
 }
 
 def configure_app(app):

--- a/corptest/controller.py
+++ b/corptest/controller.py
@@ -19,7 +19,7 @@ except ImportError:
     from urllib import unquote as unquote
 
 from flask import render_template, send_file
-from corptest import APP
+from corptest import APP, __version__
 from corptest.database import DB_SESSION
 from corptest.model import AS3BucketSource, FileSystemSource
 from corptest.sources import SourceKey, FileSystem, AS3Bucket
@@ -76,6 +76,11 @@ def download_fs(folder_id, encoded_filepath):
 def download_bucket(bucket_id, encoded_filepath):
     """Download a file from an AS3 source."""
     return _download_item('bucket', AS3BucketSource.by_id(bucket_id), encoded_filepath)
+
+@APP.route("/about")
+def about():
+    """Show the application about and config page"""
+    return render_template('about.html', config=APP.config, version=__version__)
 
 @APP.teardown_appcontext
 def shutdown_session(exception=None):

--- a/corptest/corpora.py
+++ b/corptest/corpora.py
@@ -15,7 +15,7 @@
 import collections
 from datetime import datetime
 import errno
-import os
+import os.path
 import time
 
 from corptest.utilities import check_param_not_none, Extension, sha1_path

--- a/corptest/doi.py
+++ b/corptest/doi.py
@@ -161,16 +161,3 @@ def scrape_datacite_doi(datacentre_page_rel_url):
             if len(href_parts) > 2:
                 return href_parts[2], href_parts[3]
     return None, None
-
-def main():
-    """
-    Main method entry point, parses DOIs from Datacite and outputs to
-    STDOUT.
-    """
-    DataciteDoiLookup.initialise()
-    for doi in DataciteDoiLookup.DATACENTRES:
-        datacentre = DataciteDoiLookup.lookup_by_doi(doi)
-        print(str(datacentre))
-
-if __name__ == "__main__":
-    main()

--- a/corptest/model.py
+++ b/corptest/model.py
@@ -12,7 +12,7 @@
 """SQL Alchemy database model classes."""
 from datetime import datetime
 import errno
-import os
+import os.path
 from sqlalchemy import Column, DateTime, Integer, String, ForeignKey, UniqueConstraint
 from sqlalchemy.orm import backref, relationship
 
@@ -597,6 +597,19 @@ class ByteSequence(BASE):
         """Add a ByteSequence instance to the table."""
         check_param_not_none(byte_sequence, "byte_sequence")
         _add(byte_sequence)
+
+    @staticmethod
+    def is_sha1(maybe_sha):
+        """Method that checks whether a passed string is a valid sha1 hash string, that
+        is a 40 character hex string. Thanks to mVChr from this Stack Overflow thread:
+        http://stackoverflow.com/questions/32234169/sha1-string-regex-for-python."""
+        if len(maybe_sha) != 40:
+            return False
+        try:
+            int(maybe_sha, 16)
+        except ValueError:
+            return False
+        return True
 
 def _add(obj):
     """Add an object instance to the database."""

--- a/corptest/templates/about.html
+++ b/corptest/templates/about.html
@@ -1,0 +1,17 @@
+{% extends "page.html" %}
+{% block title %}About{% endblock %}
+{% block page_content %}
+  <h2>About the JISC RDSS File Format Analyser</h2>
+  <table class="table table-striped">
+    <tr>
+      <th>Version</th>
+      <td>{{ version }}</td>
+    </tr>
+    {%- for key, value in config.items() %}
+    <tr>
+      <th>{{ key }}</th>
+      <td>{{ value }}</td>
+      {% endfor -%}
+    </tr>
+  </table>
+{% endblock page_content %}

--- a/corptest/templates/file_details.html
+++ b/corptest/templates/file_details.html
@@ -2,7 +2,7 @@
 {% block title %}Home{% endblock %}
 {% block page_content %}
   <h2>{{ source_item.name }}</h2>
-  <p><a href="/{{ source_type }}/{{ source_item.id }}/">{{ source_item.name }}/</a>
+  <p class="lead"><a href="/{{ source_type }}/{{ source_item.id }}/">{{ source_item.name }}/</a>
      {%- for part, part_path in enhanced_key.parts -%}
      <a href="/{{ source_type }}/{{ source_item.id }}/{{ part_path }}/">{{ part }}/</a>
      {%- endfor %}</p>

--- a/corptest/templates/navbar.html
+++ b/corptest/templates/navbar.html
@@ -14,7 +14,7 @@
         <ul class="nav navbar-nav">
           <li><a href="/search">Reports</a></li>
           <li><a href="/search">Tools</a></li>
-          <li><a href="/search">Formats</a></li>
+          <li><a href="/about">About</a></li>
         </ul>
       </div><!--/.nav-collapse -->
     </div>

--- a/corptest/templates/source_list.html
+++ b/corptest/templates/source_list.html
@@ -2,7 +2,7 @@
 {% block title %}Home{% endblock %}
 {% block page_content %}
   <h2>{{ source_item.name }}</h2>
-  <p><a href="/{{ source_type }}/{{ source_item.id }}/">{{ source_item.name }}/</a>
+  <p class="lead"><a href="/{{ source_type }}/{{ source_item.id }}/">{{ source_item.name }}/</a>
      {%- for part, part_path in filter_key.parts -%}
      <a href="/{{ source_type }}/{{ source_item.id }}/{{ part_path }}/">{{ part }}/</a>
      {%- endfor %}</p>

--- a/corptest/utilities.py
+++ b/corptest/utilities.py
@@ -23,7 +23,6 @@ class ObjectJsonEncoder(json.JSONEncoder):
         """ Custom Object JSON serialisation. """
         if isinstance(o, datetime):
             return {'__datetime__': o.replace(microsecond=0).isoformat()}
-
         return {'__{}__'.format(o.__class__.__name__): o.__dict__}
 
 def only_files(directory):

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 source ~/.venvs/fmt-sniff/bin/activate
 export FLASK_APP='corptest'
-export JISC_FFA_CONF_FILE='/vagrant/conf/example.conf'
+# export JISC_FFA_CONF_FILE='/vagrant/conf/example.conf'
+export JISC_FFA_CONF_PROFILE='vagrant'
 cd /vagrant
 flask run --port=8080 --host=0.0.0.0

--- a/scripts/setup_venv.sh
+++ b/scripts/setup_venv.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 mkdir -p ~/.venvs
-virtualenv -p python3 ~/.venvs/fmt-sniff
+virtualenv ~/.venvs/fmt-sniff
 source ~/.venvs/fmt-sniff/bin/activate
 pip install -e /vagrant
 deactivate


### PR DESCRIPTION
- added single file quick checks for File and DROID;
- added multiple format identifiers to file inforation screen;
- added detection for FIDO compatible Python 2 environment;
- added check for SHA1 string forms;
- improved use of namespacing for imports;
- `BlobStore` method to check if local present copy;
- added specific vagrant config;
- added simple about page for debug info;
- removed redundant main methods; and
- changed remaining print messages to logging.