### PR TITLE
FIX - Application credentials testing

### DIFF
--- a/corptest/model_properties.py
+++ b/corptest/model_properties.py
@@ -214,6 +214,11 @@ class KeyProperty(BASE):
         ret_val.append(self.prop.name)
         return "".join(ret_val)
 
+    @property
+    def namespace(self):
+        """Return the namespace of the source for this key property."""
+        return self.key.source.namespace
+
     def put(self):
         """Add this KeyProperty instance to the database."""
         return _add(self)
@@ -359,6 +364,11 @@ class ByteSequenceProperty(BASE):
         ret_val.append(':')
         ret_val.append(self.prop.name)
         return "".join(ret_val)
+
+    @property
+    def namespace(self):
+        """Return the namspace of the too for this byte sequence property."""
+        return self.format_tool_release.format_tool.namespace
 
     def put(self):
         """Add this ByteSequenceProperty instance to the database."""

--- a/corptest/model_sources.py
+++ b/corptest/model_sources.py
@@ -12,6 +12,7 @@
 """SQL Alchemy database model classes."""
 from datetime import datetime
 import errno
+import logging
 import os.path
 
 from sqlalchemy import and_, Column, DateTime, Integer, String, ForeignKey
@@ -456,8 +457,11 @@ class ByteSequence(BASE):
 def get_property_from_bs(byte_seq, namespace, prop_name):
     """Given a byte sequence, namespace and property name returns the value."""
     for prop in byte_seq.properties:
-        if prop.prop.namespace == namespace:
+        logging.debug("Checking prop.namespace %s against %s.", prop.namespace, namespace)
+        if prop.namespace == namespace:
+            logging.debug("Checking prop.name %s against %s.", prop.name, prop_name)
             if prop.prop.name == prop_name:
+                logging.debug("Returning %s", prop.prop_val.value)
                 return prop.prop_val.value
     return ''
 

--- a/corptest/sources.py
+++ b/corptest/sources.py
@@ -462,12 +462,18 @@ class AS3Bucket(SourceBase):
 
         try:
             cls.S3_RESOURCE.meta.client.head_bucket(Bucket=bucket_name)
-        except exceptions.ClientError as boto_excep:
+        except exceptions.ClientError as boto_client_excep:
             # If a client error is thrown, then check that it was a 404 error.
             # If it was a 404 error, then the bucket does not exist.
-            error_code = int(boto_excep.response['Error']['Code'])
+            error_code = int(boto_client_excep.response['Error']['Code'])
             if error_code == 404:
                 exists = False
+            else:
+                raise boto_client_excep
+        except exceptions.NoCredentialsError as boto_s3_creds_excep:
+            # If a boto-authentication exception is thrown then log it here
+            logging.exception("No S3 credentials found in user home directory.")
+            raise boto_s3_creds_excep
         return exists
 
     def __rep__(self): # pragma: no cover

--- a/corptest/templates/401.html
+++ b/corptest/templates/401.html
@@ -1,0 +1,7 @@
+{% extends "page.html" %}
+{% block title %}Unauthorized request.{% endblock %}
+{% block page_content %}
+  <h2>{{ unauthorized }}</h2>
+  <p>401: Unauthorized, it appears there are no S3 credentials available to the application</p>
+  <p>Please refer to the <a href="https://github.com/carlwilson/fmt-sniff#amazon-s3-credentials">Amazon S3 credenitals section of the README</a> for setup instructions.</p>
+{% endblock page_content %}


### PR DESCRIPTION
- added template file for unauthorized access page;
- added trap code for no S3 credentials to bucket check;
- application controller now raises `HTTP 401` status for no S3 credentials; and
- added namespace field to `KeyProperty` and `BytesSequenceProperty`.